### PR TITLE
Support editor settings for layout issue #7

### DIFF
--- a/addons/gdterm/terminal/inactive.tscn
+++ b/addons/gdterm/terminal/inactive.tscn
@@ -1,0 +1,23 @@
+[gd_scene format=3 uid="uid://s0kpss0ae4ke"]
+
+[node name="inactive" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="message" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -238.0
+offset_right = 238.0
+offset_bottom = 75.0
+grow_horizontal = 2
+text = "The terminal window has been disabled in the editor settings.
+
+Restart the editor to remove this window."
+horizontal_alignment = 1


### PR DESCRIPTION
Editor setting support for layout of main/bottom/both to put the terminal in different parts of the window.

Stub for theme setting, but no implementation yet