### PR TITLE
support light/dark/editor themes

### DIFF
--- a/addons/gdterm/terminal.gd
+++ b/addons/gdterm/terminal.gd
@@ -10,6 +10,7 @@ var bottom_panel_instance = null
 
 var current_theme = null
 var current_layout = null
+var active_theme = null
 
 const THEME_EDITOR : int = 0
 const THEME_DARK   : int = 1
@@ -46,10 +47,35 @@ func _on_settings_changed():
 	_apply_layout(layout)
 
 func _apply_theme(theme):
-	print("current theme: %s" % current_theme)
 	if current_theme != theme:
-		print("applying new theme: %s" % theme)
-
+		if theme == THEME_EDITOR:
+			var editor_theme = Theme.new()
+			var settings = EditorInterface.get_editor_settings()
+			var background = settings.get_setting("text_editor/theme/highlighting/background_color")
+			var foreground = settings.get_setting("text_editor/theme/highlighting/text_color")
+			editor_theme.set_theme_item(Theme.DATA_TYPE_COLOR, "background", "GDTerm", background)
+			editor_theme.set_theme_item(Theme.DATA_TYPE_COLOR, "foreground", "GDTerm", foreground)
+			editor_theme.set_theme_item(Theme.DATA_TYPE_COLOR, "black", "GDTerm", Color.BLACK)
+			editor_theme.set_theme_item(Theme.DATA_TYPE_COLOR, "white", "GDTerm", Color.WHITE)
+			editor_theme.set_theme_item(Theme.DATA_TYPE_COLOR, "red", "GDTerm", Color.RED)
+			editor_theme.set_theme_item(Theme.DATA_TYPE_COLOR, "green", "GDTerm", Color.GREEN)
+			editor_theme.set_theme_item(Theme.DATA_TYPE_COLOR, "blue", "GDTerm", Color.CORNFLOWER_BLUE)
+			editor_theme.set_theme_item(Theme.DATA_TYPE_COLOR, "yellow", "GDTerm", Color.YELLOW)
+			editor_theme.set_theme_item(Theme.DATA_TYPE_COLOR, "cyan", "GDTerm", Color.CYAN)
+			editor_theme.set_theme_item(Theme.DATA_TYPE_COLOR, "magenta", "GDTerm", Color.MAGENTA)
+			active_theme = editor_theme
+		elif theme == THEME_LIGHT:
+			active_theme = preload("res://addons/gdterm/themes/light.tres")
+		elif theme == THEME_DARK:
+			active_theme = preload("res://addons/gdterm/themes/dark.tres")
+		if main_panel_instance != null:
+			main_panel_instance.set_theme(active_theme)
+			main_panel_instance.theme_changed()
+		if bottom_panel_instance != null:
+			bottom_panel_instance.set_theme(active_theme)
+			bottom_panel_instance.theme_changed()
+		current_theme = theme
+	
 func _apply_layout(layout):
 	if current_layout != layout:
 		if layout == LAYOUT_MAIN or layout == LAYOUT_BOTH:
@@ -65,11 +91,16 @@ func _apply_layout(layout):
 					return
 			if main_panel_instance == null:
 				main_panel_instance = MainPanel.instantiate()
+				if active_theme != null:
+					main_panel_instance.set_theme(active_theme)
 				main_panel_instance.visible = show_main
 				EditorInterface.get_editor_main_screen().add_child(main_panel_instance)
 		if layout == LAYOUT_BOTTOM or layout == LAYOUT_BOTH:
 			if bottom_panel_instance == null:
 				bottom_panel_instance = BottomPanel.instantiate()
+				if active_theme != null:
+					bottom_panel_instance.set_theme(active_theme)
+					bottom_panel_instance.theme_changed()
 				add_control_to_bottom_panel(bottom_panel_instance, "Terminal")
 		if layout == LAYOUT_MAIN:
 			if bottom_panel_instance != null:

--- a/addons/gdterm/terminal/main.gd
+++ b/addons/gdterm/terminal/main.gd
@@ -1,0 +1,8 @@
+@tool
+extends PanelContainer
+
+func theme_changed():
+	$term_container.apply_themes()
+
+func _on_theme_changed():
+	theme_changed()

--- a/addons/gdterm/terminal/main.tscn
+++ b/addons/gdterm/terminal/main.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://bybyru7sqjtp7"]
+[gd_scene load_steps=6 format=3 uid="uid://bybyru7sqjtp7"]
 
+[ext_resource type="Theme" uid="uid://dg6omohogcvmn" path="res://addons/gdterm/themes/light.tres" id="1_na4fp"]
 [ext_resource type="Script" path="res://addons/gdterm/terminal/term_container.gd" id="1_ptxgd"]
+[ext_resource type="Script" path="res://addons/gdterm/terminal/main.gd" id="2_eh8tx"]
 [ext_resource type="PackedScene" uid="uid://b62ioxhftvwg7" path="res://addons/gdterm/terminal/term.tscn" id="3_u81lm"]
 [ext_resource type="AudioStream" uid="uid://dxb1sddgekrg5" path="res://addons/gdterm/audio/bell.mp3" id="5_8xiy1"]
 
@@ -12,6 +14,8 @@ grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+theme = ExtResource("1_na4fp")
+script = ExtResource("2_eh8tx")
 
 [node name="term_container" type="PanelContainer" parent="."]
 layout_mode = 2
@@ -24,6 +28,7 @@ stream = ExtResource("5_8xiy1")
 [node name="term" parent="term_container" instance=ExtResource("3_u81lm")]
 layout_mode = 2
 
+[connection signal="theme_changed" from="." to="." method="_on_theme_changed"]
 [connection signal="mouse_entered" from="term_container" to="term_container" method="_on_mouse_entered"]
 [connection signal="mouse_exited" from="term_container" to="term_container" method="_on_mouse_exited"]
 [connection signal="visibility_changed" from="term_container" to="term_container" method="_on_visibility_changed"]

--- a/addons/gdterm/terminal/term.gd
+++ b/addons/gdterm/terminal/term.gd
@@ -20,6 +20,19 @@ func _ready():
 	$scrollbar.page = $GDTerm.get_num_screen_lines()
 	$scrollbar.max_value = $GDTerm.get_num_scrollback_lines() + $GDTerm.get_num_screen_lines()
 	$scrollbar.value = $GDTerm.get_num_scrollback_lines()
+	apply_theme()
+
+func apply_theme():
+	if has_theme_color("background", "GDTerm"):  $GDTerm.background = get_theme_color("background", "GDTerm")
+	if has_theme_color("foreground", "GDTerm"): $GDTerm.foreground = get_theme_color("foreground", "GDTerm")
+	if has_theme_color("black", "GDTerm"):      $GDTerm.black      = get_theme_color("black", "GDTerm")
+	if has_theme_color("red", "GDTerm"):        $GDTerm.red        = get_theme_color("red", "GDTerm")
+	if has_theme_color("green", "GDTerm"):      $GDTerm.green      = get_theme_color("green", "GDTerm")
+	if has_theme_color("blue", "GDTerm"):       $GDTerm.blue       = get_theme_color("blue", "GDTerm")
+	if has_theme_color("cyan", "GDTerm"):       $GDTerm.cyan       = get_theme_color("cyan", "GDTerm")
+	if has_theme_color("yellow", "GDTerm"):     $GDTerm.yellow     = get_theme_color("yellow", "GDTerm")
+	if has_theme_color("magenta", "GDTerm"):    $GDTerm.magenta    = get_theme_color("magenta", "GDTerm")
+	if has_theme_color("white", "GDTerm"):      $GDTerm.white      = get_theme_color("white", "GDTerm")
 
 func _gui_input(e : InputEvent):
 	var me = e as InputEventMouseButton

--- a/addons/gdterm/terminal/term_container.gd
+++ b/addons/gdterm/terminal/term_container.gd
@@ -3,6 +3,20 @@ extends PanelContainer
 
 var _id : int = 0
 
+func apply_themes():
+	_apply_child_themes(self)
+
+func _apply_child_themes(parent):
+	for child in parent.get_children():
+		if child is VSplitContainer:
+			_apply_child_themes(child)
+		elif child is HSplitContainer:
+			_apply_child_themes(child)
+		elif child is AudioStreamPlayer:
+			pass
+		else:
+			child.apply_theme()
+
 func _ready():
 	$term.set_id(_next_id())
 	$term.bell.connect(_on_bell)

--- a/addons/gdterm/themes/dark.tres
+++ b/addons/gdterm/themes/dark.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Theme" format=3 uid="uid://dnxqwju08m5m0"]
+
+[resource]
+GDTerm/colors/background = Color(0.0666667, 0.0666667, 0.0666667, 1)
+GDTerm/colors/black = Color(0, 0, 0, 1)
+GDTerm/colors/blue = Color(0, 0, 0.733333, 1)
+GDTerm/colors/cyan = Color(0, 0.733333, 0.733333, 1)
+GDTerm/colors/foreground = Color(0.933333, 0.933333, 0.933333, 1)
+GDTerm/colors/green = Color(0, 0.733333, 0, 1)
+GDTerm/colors/magenta = Color(0.733333, 0, 0.733333, 1)
+GDTerm/colors/red = Color(0.733333, 0, 0, 1)
+GDTerm/colors/white = Color(0.733333, 0.733333, 0.733333, 1)
+GDTerm/colors/yellow = Color(0.733333, 0.733333, 0, 1)

--- a/addons/gdterm/themes/light.tres
+++ b/addons/gdterm/themes/light.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Theme" format=3 uid="uid://dg6omohogcvmn"]
+
+[resource]
+GDTerm/colors/background = Color(0.933333, 0.933333, 0.933333, 1)
+GDTerm/colors/black = Color(0, 0, 0, 1)
+GDTerm/colors/blue = Color(0, 0, 0.733333, 1)
+GDTerm/colors/cyan = Color(0, 0.733333, 0.733333, 1)
+GDTerm/colors/foreground = Color(0.0666667, 0.0666667, 0.0666667, 1)
+GDTerm/colors/green = Color(0, 0.733333, 0, 1)
+GDTerm/colors/magenta = Color(0.733333, 0, 0.733333, 1)
+GDTerm/colors/red = Color(0.733333, 0, 0, 1)
+GDTerm/colors/white = Color(0.733333, 0.733333, 0.733333, 1)
+GDTerm/colors/yellow = Color(0.733333, 0.733333, 0, 1)


### PR DESCRIPTION
Implemented 3 settings for theme:
- editor: uses backdrop and foreground from Text Editor part of Editor Settings, sets 8 colors in a fixed way
- light: uses the light.tres file for light mode
- dark: uses the dark.tres file for dark mode

Changing themes from the Editor Settings will propagate the settings down to the individual terminal windows.