### PR TITLE
Added support for extending and autoscrolling

### DIFF
--- a/addons/gdterm/plugin.cfg
+++ b/addons/gdterm/plugin.cfg
@@ -3,5 +3,5 @@
 name="gdterm"
 description="Godot In-Editor Terminal"
 author="markeel"
-version="0.95"
+version="0.98"
 script="terminal.gd"


### PR DESCRIPTION
When the shift is pressed and it would normally start a new selection and a selection is present, it will just extend the same selection.

When dragging is being performed and the mouse is either above or below the window it will scroll (if available that amount of rows up or down) so that the region can be selected.