### PR TITLE
Change panelcontainer to be margincontainer

### DIFF
--- a/addons/gdterm/terminal.gd
+++ b/addons/gdterm/terminal.gd
@@ -1,7 +1,7 @@
 @tool
 extends EditorPlugin
 
-const MainPanel = preload("res://addons/gdterm/terminal/main.tscn")
+const MainPanel = preload("res://addons/gdterm/terminal/border.tscn")
 const InactivePanel = preload("res://addons/gdterm/terminal/inactive.tscn")
 const BottomPanel = preload("res://addons/gdterm/terminal/main.tscn")
 
@@ -69,8 +69,8 @@ func _apply_theme(theme):
 		elif theme == THEME_DARK:
 			active_theme = preload("res://addons/gdterm/themes/dark.tres")
 		if main_panel_instance != null:
-			main_panel_instance.set_theme(active_theme)
-			main_panel_instance.theme_changed()
+			main_panel_instance.get_main().set_theme(active_theme)
+			main_panel_instance.get_main().theme_changed()
 		if bottom_panel_instance != null:
 			bottom_panel_instance.set_theme(active_theme)
 			bottom_panel_instance.theme_changed()
@@ -92,7 +92,7 @@ func _apply_layout(layout):
 			if main_panel_instance == null:
 				main_panel_instance = MainPanel.instantiate()
 				if active_theme != null:
-					main_panel_instance.set_theme(active_theme)
+					main_panel_instance.get_main().set_theme(active_theme)
 				main_panel_instance.visible = show_main
 				EditorInterface.get_editor_main_screen().add_child(main_panel_instance)
 		if layout == LAYOUT_BOTTOM or layout == LAYOUT_BOTH:

--- a/addons/gdterm/terminal/border.gd
+++ b/addons/gdterm/terminal/border.gd
@@ -1,0 +1,5 @@
+@tool
+extends PanelContainer
+
+func get_main() -> Control:
+	return $main

--- a/addons/gdterm/terminal/border.tscn
+++ b/addons/gdterm/terminal/border.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=3 format=3 uid="uid://mreef38eayen"]
+
+[ext_resource type="PackedScene" uid="uid://bybyru7sqjtp7" path="res://addons/gdterm/terminal/main.tscn" id="1_102el"]
+[ext_resource type="Script" path="res://addons/gdterm/terminal/border.gd" id="1_dlllo"]
+
+[node name="border" type="PanelContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("1_dlllo")
+
+[node name="main" parent="." instance=ExtResource("1_102el")]
+layout_mode = 2
+
+[connection signal="theme_changed" from="." to="." method="_on_theme_changed"]

--- a/addons/gdterm/terminal/main.gd
+++ b/addons/gdterm/terminal/main.gd
@@ -1,5 +1,5 @@
 @tool
-extends PanelContainer
+extends MarginContainer
 
 func theme_changed():
 	$term_container.apply_themes()

--- a/addons/gdterm/terminal/main.tscn
+++ b/addons/gdterm/terminal/main.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://b62ioxhftvwg7" path="res://addons/gdterm/terminal/term.tscn" id="3_u81lm"]
 [ext_resource type="AudioStream" uid="uid://dxb1sddgekrg5" path="res://addons/gdterm/audio/bell.mp3" id="5_8xiy1"]
 
-[node name="main" type="PanelContainer"]
+[node name="main" type="MarginContainer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -15,11 +15,19 @@ grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource("1_na4fp")
+theme_override_constants/margin_left = 0
+theme_override_constants/margin_top = 0
+theme_override_constants/margin_right = 0
+theme_override_constants/margin_bottom = 0
 script = ExtResource("2_eh8tx")
 
-[node name="term_container" type="PanelContainer" parent="."]
+[node name="term_container" type="MarginContainer" parent="."]
 layout_mode = 2
 size_flags_vertical = 3
+theme_override_constants/margin_left = 0
+theme_override_constants/margin_top = 0
+theme_override_constants/margin_right = 0
+theme_override_constants/margin_bottom = 0
 script = ExtResource("1_ptxgd")
 
 [node name="player" type="AudioStreamPlayer" parent="term_container"]

--- a/addons/gdterm/terminal/term_container.gd
+++ b/addons/gdterm/terminal/term_container.gd
@@ -1,5 +1,5 @@
 @tool
-extends PanelContainer
+extends MarginContainer
 
 var _id : int = 0
 


### PR DESCRIPTION
The panelcontainer classes that the main and term_container were derived from had style implications that causes too much space to be surrounding the terminal area in many styles.  This is especially true when in the bottom area.

Changing to MarginContainer and overriding to 0 margin maximizes the usable area.

The consequence of this however is that when used in the main panel there isn't enough of a border.  Instead an additional scene is used which derives from panelcontainer to use the theme specific margins for this container when used in the main window.