### PR TITLE
For windows stop using primary clipboard

### DIFF
--- a/src/gdterm/gdterm.cpp
+++ b/src/gdterm/gdterm.cpp
@@ -1,6 +1,8 @@
 
 #include "gdterm.h"
+#ifdef USE_PRIMARY_CLIPBOARD
 #include "godot_cpp/classes/display_server.hpp"
+#endif
 #include "godot_cpp/classes/global_constants.hpp"
 #include "godot_cpp/classes/input_event_mouse_button.hpp"
 #include "godot_cpp/classes/input_event_mouse_motion.hpp"
@@ -794,9 +796,11 @@ GDTerm::_gui_input(const Ref<InputEvent> & p_event) {
 				}
 				if (_selection_active) {
 					godot::String text = get_selected_text();
+#ifdef USE_PRIMARY_CLIPBOARD
 					if (text.length() > 0) {
 						godot::DisplayServer::get_singleton()->clipboard_set_primary(text);
 					}
+#endif
 				}
 			}
 		}

--- a/src/gdterm/pty/SConscript
+++ b/src/gdterm/pty/SConscript
@@ -16,6 +16,7 @@ if env["platform"] == "windows":
 	cpppath.extend([ "platform/windows" ])
 	ptyenv.Append(CCFLAGS="-DUNICODE")
 else:
+	env.Append(CPPDEFINES = "USE_PRIMARY_CLIPBOARD")
 	sources.extend(Glob("platform/linux/*.cpp"))
 	cpppath.extend([ "platform/linux" ])
 


### PR DESCRIPTION
The primary clipboard is not avaialable on windows so rather than call it and produce a warning, just suppress the call based on the platform