### PR TITLE
Change paste to use CR when CRLF in paste buffer

### DIFF
--- a/addons/gdterm/terminal/term.gd
+++ b/addons/gdterm/terminal/term.gd
@@ -94,6 +94,7 @@ func _do_copy():
 
 func _do_paste():
 	var text = DisplayServer.clipboard_get()
+	text = text.replace("\r\n", "\r")
 	if text.length() > 0:
 		$GDTerm.send_input(text)
 


### PR DESCRIPTION
Since the terminal code basically inserts the characters as if typed, the user will only type CR to generate a new line and not CRLF.  Windows command prompt window ignores the extra LF but the built in VI editor in git does not.  This results in multiple lines being generated.