### PR TITLE
Improved copy and paste handling

### DIFF
--- a/addons/gdterm/terminal/term.gd
+++ b/addons/gdterm/terminal/term.gd
@@ -113,3 +113,9 @@ func _on_visibility_changed() -> void:
 func _on_gd_term_tree_entered() -> void:
 	if visible:
 		$GDTerm.start()
+
+func _on_gd_term_paste_request() -> void:
+	_do_paste()
+
+func _on_gd_term_copy_request() -> void:
+	_do_copy()

--- a/addons/gdterm/terminal/term.tscn
+++ b/addons/gdterm/terminal/term.tscn
@@ -14,8 +14,8 @@ size = Vector2i(63, 62)
 always_on_top = true
 system_menu_id = 2
 item_count = 9
-item_0/text = "Copy"
-item_1/text = "Paste"
+item_0/text = "Copy (Shift+Ctrl+C)"
+item_1/text = "Paste (Shift+Ctrl+V)"
 item_1/id = 1
 item_2/text = "Restart"
 item_2/id = 2
@@ -53,7 +53,9 @@ value = 24.0
 [connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
 [connection signal="id_pressed" from="menu" to="." method="_on_menu_id_pressed"]
 [connection signal="bell_request" from="GDTerm" to="." method="_on_gd_term_bell_request"]
+[connection signal="copy_request" from="GDTerm" to="." method="_on_gd_term_copy_request"]
 [connection signal="inactive" from="GDTerm" to="." method="_on_gd_term_inactive"]
+[connection signal="paste_request" from="GDTerm" to="." method="_on_gd_term_paste_request"]
 [connection signal="scrollback_changed" from="GDTerm" to="." method="_on_gd_term_scrollback_changed"]
 [connection signal="tree_entered" from="GDTerm" to="." method="_on_gd_term_tree_entered"]
 [connection signal="value_changed" from="scrollbar" to="." method="_on_scrollbar_value_changed"]

--- a/src/gdterm/gdterm.h
+++ b/src/gdterm/gdterm.h
@@ -29,6 +29,8 @@ namespace godot {
 	};
 
 	struct GDTermLine {
+		int glyph_length;
+		int selectable_length;
 		std::vector<GDTermLineDirective> dirs;
 	};
 
@@ -232,7 +234,9 @@ namespace godot {
 		bool _clear_drawing();
 		void _restart_cursor();
 		bool _is_cursor_pos(int row, int col);
-		bool _is_in_selection(int row, int col);
+		bool _is_in_selection(int max_sel_col, int row, int col);
+		bool _is_control_shift_c(Key code);
+		bool _is_control_shift_v(Key code);
 		bool _is_control_tab(Key code);
 		bool _is_shift_control_tab(Key code);
 		bool _is_control_c(Key code);


### PR DESCRIPTION
The GDTerm class now supports keyboard control for copy and paste. In particular a Ctrl-Shift-C will copy the selected text and a Ctrl-Shift-V will paste text.

In addition when multiple lines of text are selected it will no longer use the large amounts of white space in the terminal window, but show and copy only from the first column to the last column with a non-space glyph.