### PR TITLE
17 feature suggestion choose shell path

### DIFF
--- a/addons/gdterm/terminal/main.gd
+++ b/addons/gdterm/terminal/main.gd
@@ -4,5 +4,8 @@ extends MarginContainer
 func theme_changed():
 	$term_container.apply_themes()
 
+func set_initial_cmds(cmds):
+	$term_container.set_initial_cmds(cmds)
+
 func _on_theme_changed():
 	theme_changed()

--- a/addons/gdterm/terminal/term_container.gd
+++ b/addons/gdterm/terminal/term_container.gd
@@ -2,9 +2,13 @@
 extends MarginContainer
 
 var _id : int = 0
+var _initial_cmds : PackedStringArray = PackedStringArray()
 
 func apply_themes():
 	_apply_child_themes(self)
+
+func set_initial_cmds(cmds):
+	_apply_child_cmds(self, cmds)
 
 func _apply_child_themes(parent):
 	for child in parent.get_children():
@@ -16,6 +20,17 @@ func _apply_child_themes(parent):
 			pass
 		else:
 			child.apply_theme()
+
+func _apply_child_cmds(parent, cmds):
+	for child in parent.get_children():
+		if child is VSplitContainer:
+			_apply_child_cmds(child, cmds)
+		elif child is HSplitContainer:
+			_apply_child_cmds(child, cmds)
+		elif child is AudioStreamPlayer:
+			pass
+		else:
+			child.apply_cmds(cmds)
 
 func _ready():
 	$term.set_id(_next_id())

--- a/src/gdterm/gdterm.cpp
+++ b/src/gdterm/gdterm.cpp
@@ -946,6 +946,7 @@ GDTerm::_gui_input(const Ref<InputEvent> & p_event) {
 				char buffer[100];
 				fill_term_string(buffer, 100, unicode, code);
 				if (_proxy != nullptr) {
+					log_pty_input(buffer);
 					_proxy->send_string(buffer);
 				} else {
 					emit_signal("bell_request");
@@ -1133,9 +1134,7 @@ GDTerm::screen_add_tag(LineTag tag) {
 	d.data.tag = tag;
 	if (_pending_target == TARGET_SCREEN) {
 		if ((_pending_screen_row >= 0) && (_pending_screen_row < _pending_screen_lines.size())) {
-			if (d.kind == DIRECTIVE_WRITE_GLYPH) {
-				_pending_screen_lines[_pending_screen_row].dirs.push_back(d);
-			}
+			_pending_screen_lines[_pending_screen_row].dirs.push_back(d);
 		}
 	} else {
 		if ((_pending_screen_row >= 0) && (_pending_screen_row < _pending_scrollback.size())) {
@@ -1173,6 +1172,7 @@ GDTerm::screen_add_glyph(const char * c, int len) {
 	GDTermLineDirective d;
 	d.kind = DIRECTIVE_WRITE_GLYPH;
 	d.data.text = std::string(c, len);
+	fprintf(stderr, "%d: glyph='%s'\n", len, d.data.text.c_str());
 	if (_pending_target == TARGET_SCREEN) {
 		if ((_pending_screen_row >= 0) && (_pending_screen_row < _pending_screen_lines.size())) {
 			_pending_screen_lines[_pending_screen_row].glyph_length += 1;
@@ -1782,8 +1782,17 @@ GDTerm::_send_input_chunk(int max_send) {
 
 	std::memcpy(buffer, bytes.ptr(), amount);
 	buffer[amount] = '\0';
+	log_pty_input(buffer);
 	if (_proxy->send_string(buffer) >= 0) {
 		_send_input_buffer = _send_input_buffer.substr(amount);
+	}
+}
+
+void
+GDTerm::log_pty_input(const char * data) {
+	if (_vt_handler_input_log != nullptr) {
+		*_vt_handler_input_log << "KEY:'" << data << "':KEY" << std::endl;
+		_vt_handler_input_log->flush();
 	}
 }
 

--- a/src/gdterm/gdterm.cpp
+++ b/src/gdterm/gdterm.cpp
@@ -1172,7 +1172,7 @@ GDTerm::screen_add_glyph(const char * c, int len) {
 	GDTermLineDirective d;
 	d.kind = DIRECTIVE_WRITE_GLYPH;
 	d.data.text = std::string(c, len);
-	fprintf(stderr, "%d: glyph='%s'\n", len, d.data.text.c_str());
+	//fprintf(stderr, "%d: glyph='%s'\n", len, d.data.text.c_str());
 	if (_pending_target == TARGET_SCREEN) {
 		if ((_pending_screen_row >= 0) && (_pending_screen_row < _pending_screen_lines.size())) {
 			_pending_screen_lines[_pending_screen_row].glyph_length += 1;

--- a/src/gdterm/gdterm.h
+++ b/src/gdterm/gdterm.h
@@ -227,6 +227,7 @@ namespace godot {
 		virtual void show_cursor(bool flag) override;
 		virtual void resize_complete() override;
 		virtual void exited() override;
+		virtual void log_pty_input(const char * data) override;
 		virtual void log_vt_handler_input(unsigned char * data, int data_len) override;
 
 	private:

--- a/src/gdterm/pty/platform/windows/pty_proxy_win.h
+++ b/src/gdterm/pty/platform/windows/pty_proxy_win.h
@@ -45,8 +45,13 @@ private:
 	HANDLE                  _to_thread;
 	unsigned char           _to_buffer[TO_BUFFER_MAX_SIZE];
 	int                     _to_buffer_pos;
+	bool                    _to_thread_started;
 
 	HANDLE                  _from_thread;
+	bool                    _from_thread_started;
+
+	std::mutex              _start_complete_mutex;
+	std::condition_variable _start_complete;
 
 	void _create_pipes_and_pty();
 	void _create_process();
@@ -62,6 +67,8 @@ private:
 	void _join_threads();
 	void _terminate_process();
 	void _close_pty();
+	void _notify_to_started();
+	void _notify_from_started();
 };
 
 #endif

--- a/src/gdterm/pty/pty_proxy.cpp
+++ b/src/gdterm/pty/pty_proxy.cpp
@@ -269,6 +269,7 @@ extern "C" {
 			case TMT_MSG_ANSWER:
 			{
 				const char * msg = (const char *)r;
+				proxy->_log_pty_input(msg);
 				proxy->send_string(msg);
 				break;
 			}
@@ -383,6 +384,13 @@ void
 PtyProxy::_show_cursor(bool flag) {
 	if (_renderer != nullptr) {
 		_renderer->show_cursor(flag);
+	}
+}
+
+void
+PtyProxy::_log_pty_input(const char * msg) {
+	if (_renderer != nullptr) {
+		_renderer->log_pty_input(msg);
 	}
 }
 

--- a/src/gdterm/pty/pty_proxy.h
+++ b/src/gdterm/pty/pty_proxy.h
@@ -67,6 +67,7 @@ class TermRenderer {
 		virtual void show_cursor(bool flag) = 0;
 		virtual void resize_complete() = 0;
 		virtual void exited() = 0;
+		virtual void log_pty_input(const char * data) = 0;
 		virtual void log_vt_handler_input(unsigned char * data, int data_len) = 0;
 };
 
@@ -95,6 +96,7 @@ public:
 	void _update_cursor(int row, int col);
 	void _play_bell();
 	void _show_cursor(bool flag);
+	void _log_pty_input(const char * msg);
 
 protected:
 	TermRenderer * _renderer;


### PR DESCRIPTION
There were lots of ways to solve this issue.

What I ended up implementing was the ability to automatically issue commands on startup of the terminal.

Rather than just change the shell as a configuration option, I thought it would be more useful and symmetric between the different platform implementations, to always start on a known shell (for Windows CMD.EXE, and for Linux the shell in $SHELL).  

In any environment there may be different actions in the terminal that could be taken automatically (such as CD'ing to a directory to run your server, look at your logs, or start another client instance), or start a different type of shell (such as running Powershell).

This technique seems to have the maximum flexibility.

To provide initial commands, simply add them to the GDTerm editor settings under Initial Commands.

They will not take effect until the terminal is reset or a new terminal window is opened.