### PR TITLE
Switch backspace key to produce DEL instead of BS

### DIFF
--- a/src/gdterm/key_converter.cpp
+++ b/src/gdterm/key_converter.cpp
@@ -246,10 +246,14 @@ fill_term_string(char * buffer, int buf_len, wchar_t unicode, godot::Key key) {
 			strcpy(buffer, "\t");
 			break;
 		case godot::Key::KEY_BACKSPACE:
-			strcpy(buffer, TMT_KEY_BACKSPACE);
+			if (ctrl) {
+				strcpy(buffer, TMT_KEY_BACKSPACE);
+			} else {
+				strcpy(buffer, "\x7f");
+			}
 			break;
 		case godot::Key::KEY_DELETE:
-			strcpy(buffer, "\x7f");
+			strcpy(buffer, "\x1b[3~");
 			break;
 		case godot::Key::KEY_KP_ENTER:
 			strcpy(buffer, "\r");


### PR DESCRIPTION
The recent versions of Windows CMD shell expects the backspace key to produce a DEL instead of a BS.  This is apparently not an an issue with Linux which treats DEL and BS the same way, so the easy thing is to just switch the backspace to produce DEL.