### PR TITLE
Enabled META and ALT keys to work in Emacs by making them send Escape

### DIFF
--- a/src/gdterm/key_converter.cpp
+++ b/src/gdterm/key_converter.cpp
@@ -162,8 +162,6 @@ fill_term_string(char * buffer, int buf_len, wchar_t unicode, godot::Key key) {
 		case godot::Key::KEY_NONE:
 		case godot::Key::KEY_SHIFT:
 		case godot::Key::KEY_CTRL:
-		case godot::Key::KEY_META:
-		case godot::Key::KEY_ALT:
 		case godot::Key::KEY_CAPSLOCK:
 		case godot::Key::KEY_NUMLOCK:
 		case godot::Key::KEY_SCROLLLOCK:
@@ -241,6 +239,8 @@ fill_term_string(char * buffer, int buf_len, wchar_t unicode, godot::Key key) {
 		case godot::Key::KEY_F34:
 		case godot::Key::KEY_F35:
 			break;
+		case godot::Key::KEY_META:
+		case godot::Key::KEY_ALT:			
 		case godot::Key::KEY_ESCAPE:
 			strcpy(buffer, "\x1b");
 			break;


### PR DESCRIPTION
I tried your addon and it is fantastic. The only issue I had is I wanted to run Emacs within the terminal but the M-<key> combinations were not working, so I have made a small update to make the META and ALT keys send an Escape to resolve that issue.