### PR TITLE
Support Alt/Meta config option

### DIFF
--- a/addons/gdterm/terminal.gd
+++ b/addons/gdterm/terminal.gd
@@ -12,6 +12,7 @@ var current_theme = null
 var current_layout = null
 var active_theme = null
 var active_initial_cmds = null
+var active_alt_meta = false
 
 const THEME_EDITOR : int = 0
 const THEME_DARK   : int = 1
@@ -41,6 +42,11 @@ var initial_cmds_info = {
 	"hint": PROPERTY_HINT_MULTILINE_TEXT,
 }
 
+var send_alt_meta_as_esc_info = {
+	"name": "gdterm/send_alt_meta_as_esc",
+	"type": TYPE_BOOL,
+}
+
 func _on_settings_changed():
 	var settings = EditorInterface.get_editor_settings()
 	
@@ -53,8 +59,12 @@ func _on_settings_changed():
 	var initial_cmds = String()
 	if settings.has_setting("gdterm/initial_commands"):
 		initial_cmds = settings.get_setting("gdterm/initial_commands")
+	var send_alt_meta_as_esc = false
+	if settings.has_setting("gdterm/send_alt_meta_as_esc"):
+		send_alt_meta_as_esc = settings.get_setting("gdterm/send_alt_meta_as_esc")
 	_apply_theme(theme)
 	_apply_initial_cmds(initial_cmds)
+	_apply_term_alt_meta_setting(send_alt_meta_as_esc)
 	_apply_layout(layout)
 
 func _apply_theme(theme):
@@ -144,6 +154,14 @@ func _apply_initial_cmds(cmds):
 			bottom_panel_instance.set_initial_cmds(cmds)
 		active_initial_cmds = cmds
 
+func _apply_term_alt_meta_setting(setting):
+	if active_alt_meta != setting:
+		if main_panel_instance != null:
+			main_panel_instance.get_main().set_alt_meta(setting)
+		if bottom_panel_instance != null:
+			bottom_panel_instance.set_alt_meta(setting)
+		active_alt_meta = setting
+
 func _enter_tree() -> void:
 	var settings = EditorInterface.get_editor_settings()
 	
@@ -162,6 +180,13 @@ func _enter_tree() -> void:
 		settings.set_setting("gdterm/initial_commands", initial_cmds)
 	_apply_initial_cmds(initial_cmds)
 
+	var alt_meta_setting = false
+	if settings.has_setting("gdterm/sent_alt_meta_as_esc"):
+		alt_meta_setting = settings.get_setting("gdterm/send_alt_meta_as_esc")
+	else:
+		settings.set_setting("gdterm/send_alt_meta_as_esc", alt_meta_setting)
+	_apply_term_alt_meta_setting(alt_meta_setting)
+
 	var layout = LAYOUT_MAIN
 	if settings.has_setting("gdterm/layout"):
 		layout = settings.get_setting("gdterm/layout")
@@ -174,6 +199,7 @@ func _enter_tree() -> void:
 	settings.add_property_info(theme_property_info)
 	settings.add_property_info(layout_property_info)
 	settings.add_property_info(initial_cmds_info)
+	settings.add_property_info(send_alt_meta_as_esc_info)
 	settings.settings_changed.connect(_on_settings_changed)
 	
 	# Hide the main panel. Very much required.

--- a/addons/gdterm/terminal/main.gd
+++ b/addons/gdterm/terminal/main.gd
@@ -7,5 +7,8 @@ func theme_changed():
 func set_initial_cmds(cmds):
 	$term_container.set_initial_cmds(cmds)
 
+func set_alt_meta(setting):
+	$term_container.set_alt_meta(setting)
+
 func _on_theme_changed():
 	theme_changed()

--- a/addons/gdterm/terminal/term.gd
+++ b/addons/gdterm/terminal/term.gd
@@ -27,6 +27,9 @@ func _ready():
 func apply_cmds(cmds):
 	_cmds = cmds
 
+func apply_alt_meta(setting):
+	$GDTerm.send_alt_meta_as_escape = setting
+
 func apply_theme():
 	if has_theme_color("background", "GDTerm"):     $GDTerm.background     = get_theme_color("background", "GDTerm")
 	if has_theme_color("foreground", "GDTerm"):     $GDTerm.foreground     = get_theme_color("foreground", "GDTerm")

--- a/addons/gdterm/terminal/term_container.gd
+++ b/addons/gdterm/terminal/term_container.gd
@@ -10,6 +10,9 @@ func apply_themes():
 func set_initial_cmds(cmds):
 	_apply_child_cmds(self, cmds)
 
+func set_alt_meta(setting):
+	_apply_child_alt_meta(self, setting)
+
 func _apply_child_themes(parent):
 	for child in parent.get_children():
 		if child is VSplitContainer:
@@ -31,6 +34,17 @@ func _apply_child_cmds(parent, cmds):
 			pass
 		else:
 			child.apply_cmds(cmds)
+
+func _apply_child_alt_meta(parent, setting):
+	for child in parent.get_children():
+		if child is VSplitContainer:
+			_apply_child_alt_meta(child, setting)
+		elif child is HSplitContainer:
+			_apply_child_alt_meta(child, setting)
+		elif child is AudioStreamPlayer:
+			pass
+		else:
+			child.apply_alt_meta(setting)
 
 func _ready():
 	$term.set_id(_next_id())

--- a/src/gdterm/gdterm.cpp
+++ b/src/gdterm/gdterm.cpp
@@ -79,6 +79,8 @@ void GDTerm::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_background", "background"), &GDTerm::set_background);
 	ClassDB::bind_method(D_METHOD("get_vt_handler_log_path"), &GDTerm::get_vt_handler_log_path);
 	ClassDB::bind_method(D_METHOD("set_vt_handler_log_path", "vt_handler_log_path"), &GDTerm::set_vt_handler_log_path);
+	ClassDB::bind_method(D_METHOD("get_send_alt_meta_as_escape"), &GDTerm::get_send_alt_meta_as_escape);
+	ClassDB::bind_method(D_METHOD("set_send_alt_meta_as_escape", "send_alt_meta_as_escape"), &GDTerm::set_send_alt_meta_as_escape);
 	ClassDB::bind_method(D_METHOD("clear"), &GDTerm::clear);
 	ClassDB::bind_method(D_METHOD("is_active"), &GDTerm::is_active);
 	ClassDB::bind_method(D_METHOD("start"), &GDTerm::start);
@@ -122,6 +124,7 @@ void GDTerm::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "background"), "set_background", "get_background");
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "vt_handler_log_path"), "set_vt_handler_log_path", "get_vt_handler_log_path");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "send_alt_meta_as_escape"), "set_send_alt_meta_as_escape", "get_send_alt_meta_as_escape");
 
 	ADD_SIGNAL(MethodInfo("bell_request"));
 	ADD_SIGNAL(MethodInfo("inactive"));
@@ -203,6 +206,9 @@ GDTerm::GDTerm() {
 
 	// Logging
 	_vt_handler_input_log = nullptr;
+
+	// Terminal Settings
+	_send_alt_meta_as_escape = false;
 }
 
 GDTerm::~GDTerm() {
@@ -482,6 +488,16 @@ GDTerm::set_vt_handler_log_path(String log_path) {
 			_vt_handler_input_log->open(os_path.utf8(), std::ios::out);
 		}
 	}
+}
+
+void 
+GDTerm::set_send_alt_meta_as_escape(bool f) {
+	_send_alt_meta_as_escape = f;
+}
+
+bool 
+GDTerm::get_send_alt_meta_as_escape() const {
+	return _send_alt_meta_as_escape;
 }
 
 Color
@@ -959,7 +975,7 @@ GDTerm::_gui_input(const Ref<InputEvent> & p_event) {
 				next->grab_focus();
 			} else {
 				char buffer[100];
-				fill_term_string(buffer, 100, unicode, code);
+				fill_term_string(buffer, 100, unicode, code, _send_alt_meta_as_escape);
 				if (_proxy != nullptr) {
 					log_pty_input(buffer);
 					_proxy->send_string(buffer);

--- a/src/gdterm/gdterm.h
+++ b/src/gdterm/gdterm.h
@@ -60,6 +60,7 @@ namespace godot {
 		Color      foreground;
 		Color      background;
 		String     vt_handler_log_path;
+		bool       send_alt_meta_as_escape;
 
 		PtyProxy * _proxy;
 
@@ -119,6 +120,9 @@ namespace godot {
 
 		// Logging
 		std::fstream * _vt_handler_input_log;
+
+		// Terminal Settings
+		bool _send_alt_meta_as_escape;
 
 	protected:
 		static void _bind_methods();
@@ -195,6 +199,9 @@ namespace godot {
 
 		void set_vt_handler_log_path(String c);
 		String get_vt_handler_log_path() const;
+
+		void set_send_alt_meta_as_escape(bool f);
+		bool get_send_alt_meta_as_escape() const;
 
 		void clear();
 		void start();

--- a/src/gdterm/key_converter.h
+++ b/src/gdterm/key_converter.h
@@ -4,6 +4,6 @@
 #include "godot_cpp/classes/global_constants.hpp"
 
 //const char * lookup_term_string(godot::Key key);
-void fill_term_string(char * buffer, int buf_len, wchar_t unicode, godot::Key key);
+void fill_term_string(char * buffer, int buf_len, wchar_t unicode, godot::Key key, bool send_alt_meta_as_esc);
 
 #endif

--- a/test/gdterm/proxy_test.cpp
+++ b/test/gdterm/proxy_test.cpp
@@ -1,9 +1,9 @@
-#include "pty_proxy.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <thread>
 #include <chrono>
+#include "pty_proxy.h"
 
 extern PtyProxy * create_proxy(TermRenderer * renderer);
 


### PR DESCRIPTION
This will allow the Alt/Meta key to be sent as an <ESC> <char> when entered.  It will only send it when a character is actually being sent, not when the Alt or Meta key are actually pressed.